### PR TITLE
Fixed a multi-window empty document bug

### DIFF
--- a/hclsliders/hclsliders.py
+++ b/hclsliders/hclsliders.py
@@ -1777,9 +1777,10 @@ class HCLSliders(DockWidget):
 
     def canvasChanged(self, canvas):
         if self.document != Application.activeDocument():
-            self.document = Application.activeDocument()
-            self.trc = self.profileTRC(self.document.colorProfile())
             self.color.resetColors()
             self.syntax.setText("")
-            self.getKritaColors()
+            self.document = Application.activeDocument()
+            if self.document:
+                self.trc = self.profileTRC(self.document.colorProfile())    
+                self.getKritaColors()
 


### PR DESCRIPTION
Fixed a bug where after closing another window, an error occurs if the active window has no document opened.