### PR TITLE
Added Oklch sliders and refined syntax parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ This plugin contains sliders for various hue/colorfulness/lightness models for u
 
 *OKHSL* (Hue, Interpolated Saturation, Referenced Lightness)
 
+*OKHCL* (Hue, Chroma, Lightness)
+
 ### Accepted CSS Syntax
 
-*Hexicimal* notations: Must be 6 digits, i.e. #RRGGBB
+*Heximal* notations: Must be 6 digits, i.e. `#AABBCC`
 
-*Oklab* notations: RGB values will be clipped to the sRGB gamut
+*Oklab* notations: RGB values will be clipped to the sRGB gamut, i.e. `oklab(50% 0 0)`
 
-*Oklch* notations: Hue must be given in degrees and RGB will be clipped
+*Oklch* notations: Hue must be given in degrees and RGB will be clipped, i.e. `oklch(50% 0.1 300)`
+
+Some extra non-standard formats are also supported when parsing:
+
+- Heximal without the `#` prefix, i.e. `AABBCC`
+- Oklab/Oklch without the `okxxx` and brackets, i.e. `50% 0 0` (Or not using percentage value, like `0.5`)
 
 ## Slider Interactions
 Left Mouse Button/Pen **Press**: Set value for channel

--- a/hclsliders/colorconversion.py
+++ b/hclsliders/colorconversion.py
@@ -90,6 +90,7 @@ class Convert:
             attempt.append((Convert.oklchSToRgbF, syntax, NOTATION[2]))
         
         components = syntax.split(" ")
+        print(f"Components: {components}")
         if len(components) == 3:
             if curNotation == NOTATION[1] or components[1][0] == "-" or components[2][0] == "-":
                 attempt.append((Convert.oklabSToRgbF, f"oklab({components[0]} {components[1]} {components[2]})", NOTATION[1]))
@@ -97,11 +98,13 @@ class Convert:
                 attempt.append((Convert.oklchSToRgbF, f"oklch({components[0]} {components[1]} {components[2]})", NOTATION[2]))
 
         for fn, val, notation in attempt:
+            print(f"Testing {fn.__name__} with {val}...")
             res = fn(val, trc)
             if res:
+                print(f"Parsed syntax in notation {notation}: {syntax} -> {res}")
                 return res, notation
         
-        raise ValueError(f"Unable to parse syntax: {syntax}")
+        return None
 
     @staticmethod
     def roundZero(n: float, d: int):
@@ -429,7 +432,9 @@ class Convert:
     
     @staticmethod
     def hexSToRgbF(syntax: str, trc: str):
-        if len(syntax) != 7:
+        print(syntax)
+
+        if not syntax.startswith("#") or len(syntax) != 7:
             return None
         try:
             r = int(syntax[1:3], 16) / 255.0
@@ -461,6 +466,8 @@ class Convert:
     
     @staticmethod
     def oklabSToRgbF(syntax: str, trc: str):
+        print(syntax)
+
         strings = syntax[5:].strip("( )").split()
         if len(strings) != 3:
             return None
@@ -534,6 +541,8 @@ class Convert:
     
     @staticmethod
     def oklchSToRgbF(syntax: str, trc: str):
+        print(syntax)
+
         strings = syntax[5:].strip("( )").split()
         if len(strings) != 3:
             return None
@@ -552,7 +561,8 @@ class Convert:
             h = Convert.clampF(float(h.strip("deg")), 360.0)
         except ValueError:
             return None
-        return Convert.oklchToRgbF(l, c, h, -1, trc)
+        
+        return Convert.oklchToRgbF(l * 100, c * 100, h, -1, trc)
     
     @staticmethod
     def oklchToRgbF(l: float, c: float, h: float, u: float, trc: str):

--- a/hclsliders/colorconversion.py
+++ b/hclsliders/colorconversion.py
@@ -526,18 +526,21 @@ class Convert:
             print("Invalid syntax")
             return
         return Convert.oklchToRgbF(l, c, h, trc)
-
+    
     @staticmethod
     def oklchToRgbF(l: float, c: float, h: float, u: float, trc: str):
         l = l / 100
-        c = c / 100
-        u = u / 100
         # clip chroma if exceed sRGB gamut
         ab = Convert.polarToCartesian(1, h)
         if c:
-            u = Convert.findGamutIntersection(*ab, l, 1, l)
-            if c > u:
-                c = u
+            cMax = Convert.findGamutIntersection(*ab, l, 1, l)
+            if u == -1:
+                c = c / 100
+                if c > cMax:
+                    c = cMax
+            else:
+                s = c / u
+                c = s * cMax
         rgb = Convert.oklabToLinear(l, ab[0] * c, ab[1] * c)
         # if rgb not linear, perform transfer functions for components
         r = Convert.componentToSRGB(rgb[0]) if trc == "sRGB" else rgb[0]

--- a/hclsliders/colorconversion.py
+++ b/hclsliders/colorconversion.py
@@ -471,7 +471,6 @@ class Convert:
         l = oklab[0]
         ch = Convert.cartesianToPolar(oklab[1], oklab[2])
         c = ch[0]
-        h = 0
         # chroma of neutral colors will not be exactly 0 due to floating point errors
         if c < 0.000001:
             # use current hue to calulate chroma limit in sRGB gamut for neutral colors
@@ -487,7 +486,6 @@ class Convert:
             else:
                 h = round(ch[1], 2)
                 c = Convert.roundZero(c, 4)
-                
             # a and b must be normalized to c = 1 to calculate chroma limit in sRGB gamut
             a_ = oklab[1] / c
             b_ = oklab[2] / c

--- a/hclsliders/colorconversion.py
+++ b/hclsliders/colorconversion.py
@@ -552,7 +552,7 @@ class Convert:
             h = Convert.clampF(float(h.strip("deg")), 360.0)
         except ValueError:
             return None
-        return Convert.oklchToRgbF(l, c, h, trc)
+        return Convert.oklchToRgbF(l, c, h, -1, trc)
     
     @staticmethod
     def oklchToRgbF(l: float, c: float, h: float, u: float, trc: str):

--- a/hclsliders/hclsliders.py
+++ b/hclsliders/hclsliders.py
@@ -1117,7 +1117,8 @@ class HCLSliders(DockWidget):
                 except ValueError:
                     print(f"Invalid displacement amount for {name}")
 
-                if name[:3] in ["hcy", "okhcl", "oklch"] and name[-6:] != "Chroma":
+                if any(x in name for x in ["hcy", "okhcl", "oklch"]) and name[-6:] != "Chroma":
+                    print(name)
                     channel.scale = settings[2] == "True"
 
                 if name[-3:] == "Hue":
@@ -1168,7 +1169,7 @@ class HCLSliders(DockWidget):
             settings.append(str(channel.slider.interval))
             settings.append(str(channel.slider.displacement))
 
-            if (name[:3] == "hcy" or name[:5] == "okhcl") and name[-6:] != "Chroma":
+            if any(x in name for x in ["hcy", "okhcl", "oklch"]) and name[-6:] != "Chroma":
                 settings.append(str(channel.scale))
             if name[-3:] == "Hue":
                 settings.append(str(channel.colorful))
@@ -1332,6 +1333,7 @@ class HCLSliders(DockWidget):
     def updateChannels(self, values: tuple|float, name: str=None, widget: str=None):
         self.timer.stop()
         self.blockChannels(True)
+        print(values, name)
         
         if type(values) is tuple:
             # update color from krita that is not adjusted by this plugin
@@ -1467,6 +1469,7 @@ class HCLSliders(DockWidget):
                 chroma = self.oklchChroma.value()
                 limit = -1
                 if channel.scale:
+                    print(self.oklchChroma.limit, chroma)
                     if self.oklchChroma.limit > 0:
                         self.oklchChroma.clip = chroma
                     limit = self.oklchChroma.limit
@@ -1479,6 +1482,7 @@ class HCLSliders(DockWidget):
                 self.setKritaColor(rgb)
                 if name[-6:] != "Chroma":
                     oklch = Convert.rgbFToOklch(*rgb, hue, self.trc)
+                    print(oklch)
                     self.oklchChroma.setLimit(oklch[3])
                     self.oklchChroma.setValue(oklch[1])
                 self.setChannelValues("hsv", rgb)

--- a/hclsliders/hclsliders.py
+++ b/hclsliders/hclsliders.py
@@ -1117,7 +1117,7 @@ class HCLSliders(DockWidget):
                 except ValueError:
                     print(f"Invalid displacement amount for {name}")
 
-                if (name[:3] == "hcy" or name[:5] == "okhcl") and name[-6:] != "Chroma":
+                if name[:3] in ["hcy", "okhcl", "oklch"] and name[-6:] != "Chroma":
                     channel.scale = settings[2] == "True"
 
                 if name[-3:] == "Hue":

--- a/hclsliders/hclsliders.py
+++ b/hclsliders/hclsliders.py
@@ -1118,7 +1118,6 @@ class HCLSliders(DockWidget):
                     print(f"Invalid displacement amount for {name}")
 
                 if any(x in name for x in ["hcy", "okhcl", "oklch"]) and name[-6:] != "Chroma":
-                    print(name)
                     channel.scale = settings[2] == "True"
 
                 if name[-3:] == "Hue":
@@ -1333,7 +1332,6 @@ class HCLSliders(DockWidget):
     def updateChannels(self, values: tuple|float, name: str=None, widget: str=None):
         self.timer.stop()
         self.blockChannels(True)
-        print(values, name)
         
         if type(values) is tuple:
             # update color from krita that is not adjusted by this plugin
@@ -1469,7 +1467,6 @@ class HCLSliders(DockWidget):
                 chroma = self.oklchChroma.value()
                 limit = -1
                 if channel.scale:
-                    print(self.oklchChroma.limit, chroma)
                     if self.oklchChroma.limit > 0:
                         self.oklchChroma.clip = chroma
                     limit = self.oklchChroma.limit
@@ -1482,7 +1479,6 @@ class HCLSliders(DockWidget):
                 self.setKritaColor(rgb)
                 if name[-6:] != "Chroma":
                     oklch = Convert.rgbFToOklch(*rgb, hue, self.trc)
-                    print(oklch)
                     self.oklchChroma.setLimit(oklch[3])
                     self.oklchChroma.setValue(oklch[1])
                 self.setChannelValues("hsv", rgb)

--- a/hclsliders/hclsliders.py
+++ b/hclsliders/hclsliders.py
@@ -1815,7 +1815,10 @@ class HCLSliders(DockWidget):
         if syntax == self.text:
             return
 
-        rgb, notation = Convert.parseAnything(syntax, self.trc, self.notation)
+        result = Convert.parseAnything(syntax, self.trc, self.notation)
+        if result is None:
+            return
+        rgb, notation = result
         
         self.setNotation(notation)
         if notation != self.notation:

--- a/hclsliders/hclsliders.py
+++ b/hclsliders/hclsliders.py
@@ -813,7 +813,7 @@ class SliderConfig(QDialog):
                 tabLayout.addWidget(snapGroup)
                 
                 param = name[len(model):]
-                if (model == 'HCY' or model == 'OKHCL') and param != 'Chroma':
+                if model in ['HCY', 'OKHCL', 'OKLCH'] and param != 'Chroma':
                     radioGroup = QGroupBox("Chroma Mode")
                     radioGroup.setFixedHeight(GROUPBOX_HEIGHT)
                     radioGroup.setToolTip("Switches how chroma is adjusted \
@@ -1073,11 +1073,11 @@ class HCLSliders(DockWidget):
         self.okhslSaturation = ColorChannel("okhslSaturation", self)
         self.okhslLightness = ColorChannel("okhslLightness", self)
 
-        self.oklchHue = ColorChannel("oklchHue", self)
-        self.oklchHue.scale = False
-        self.oklchChroma = ColorChannel("oklchChroma", self)
         self.oklchLightness = ColorChannel("oklchLightness", self)
         self.oklchLightness.scale = False
+        self.oklchChroma = ColorChannel("oklchChroma", self)
+        self.oklchHue = ColorChannel("oklchHue", self)
+        self.oklchHue.scale = False
         
         self.mainLayout.addLayout(self.channelLayout)
 

--- a/hclsliders/hclsliders.py
+++ b/hclsliders/hclsliders.py
@@ -43,29 +43,7 @@ from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QDoubleSpinBox, 
 from krita import DockWidget, ManagedColor
 
 from .colorconversion import Convert
-
-DOCKER_NAME = 'HCL Sliders'
-# adjust plugin sizes and update timing here
-TIME = 100 # ms time for plugin to update color from krita, faster updates may make krita slower
-DELAY = 300 # ms delay updating color history to prevent flooding when using the color picker
-DISPLAY_HEIGHT = 25 # px for color display panel at the top
-CHANNEL_HEIGHT = 19 # px for channels, also influences hex/ok syntax box and buttons
-MODEL_SPACING = 6 # px for spacing between color models
-HISTORY_HEIGHT = 16 # px for color history and area of each color box
-VALUES_WIDTH = 63 # px for spinboxes containing channel values
-LABEL_WIDTH = 11 # px for spacing of channel indicator/letter
-# adjust various sizes of config menu
-CONFIG_SIZE = (468, 230) # (width in px, height in px) size for config window
-SIDEBAR_WIDTH = 76 # px for sidebar containing channel selection and others button 
-GROUPBOX_HEIGHT = 64 # px for groupboxes of cursor snapping, chroma mode and color history
-SPINBOX_WIDTH = 72 # px for spinboxes of interval, displacement and memory
-OTHERS_HEIGHT = 12 # px for spacing before color history in others page
-# compatible color profiles in krita
-SRGB = ('sRGB-elle-V2-srgbtrc.icc', 'sRGB built-in', 
-        'Gray-D50-elle-V2-srgbtrc.icc', 'Gray-D50-elle-V4-srgbtrc.icc')
-LINEAR = ('sRGB-elle-V2-g10.icc', 'krita-2.5, lcms sRGB built-in with linear gamma TRC', 
-          'Gray-D50-elle-V2-g10.icc', 'Gray-D50-elle-V4-g10.icc')
-NOTATION = ('HEX', 'OKLAB', 'OKLCH')
+from .settings import *
 
 
 class ColorDisplay(QWidget):
@@ -1837,18 +1815,9 @@ class HCLSliders(DockWidget):
         if syntax == self.text:
             return
 
-        rgb = None
-        notation = self.notation
-        if syntax[:1] == "#":
-            self.setNotation(NOTATION[0])
-            rgb = Convert.hexSToRgbF(syntax, self.trc)
-        elif syntax[:5].upper() == NOTATION[1]:
-            self.setNotation(NOTATION[1])
-            rgb = Convert.oklabSToRgbF(syntax, self.trc)
-        elif syntax[:5].upper() == NOTATION[2]:
-            self.setNotation(NOTATION[2])
-            rgb = Convert.oklchSToRgbF(syntax, self.trc)
+        rgb, notation = Convert.parseAnything(syntax, self.trc, self.notation)
         
+        self.setNotation(notation)
         if notation != self.notation:
             self.updateNotations()
         if rgb:

--- a/hclsliders/settings.py
+++ b/hclsliders/settings.py
@@ -1,0 +1,22 @@
+DOCKER_NAME = 'HCL Sliders'
+# adjust plugin sizes and update timing here
+TIME = 100 # ms time for plugin to update color from krita, faster updates may make krita slower
+DELAY = 300 # ms delay updating color history to prevent flooding when using the color picker
+DISPLAY_HEIGHT = 25 # px for color display panel at the top
+CHANNEL_HEIGHT = 19 # px for channels, also influences hex/ok syntax box and buttons
+MODEL_SPACING = 6 # px for spacing between color models
+HISTORY_HEIGHT = 16 # px for color history and area of each color box
+VALUES_WIDTH = 63 # px for spinboxes containing channel values
+LABEL_WIDTH = 11 # px for spacing of channel indicator/letter
+# adjust various sizes of config menu
+CONFIG_SIZE = (468, 230) # (width in px, height in px) size for config window
+SIDEBAR_WIDTH = 76 # px for sidebar containing channel selection and others button 
+GROUPBOX_HEIGHT = 64 # px for groupboxes of cursor snapping, chroma mode and color history
+SPINBOX_WIDTH = 72 # px for spinboxes of interval, displacement and memory
+OTHERS_HEIGHT = 12 # px for spacing before color history in others page
+# compatible color profiles in krita
+SRGB = ('sRGB-elle-V2-srgbtrc.icc', 'sRGB built-in', 
+        'Gray-D50-elle-V2-srgbtrc.icc', 'Gray-D50-elle-V4-srgbtrc.icc')
+LINEAR = ('sRGB-elle-V2-g10.icc', 'krita-2.5, lcms sRGB built-in with linear gamma TRC', 
+          'Gray-D50-elle-V2-g10.icc', 'Gray-D50-elle-V4-g10.icc')
+NOTATION = ('HEX', 'OKLAB', 'OKLCH')


### PR DESCRIPTION
Added Oklch sliders
<img width="304" height="449" alt="image" src="https://github.com/user-attachments/assets/75812c6b-c6bb-40f3-be35-095604a2c73e" />
<img width="470" height="262" alt="image" src="https://github.com/user-attachments/assets/f598e622-209a-4079-8ef9-7e820f6d3b63" />

Refined syntax parsing. See `Convert.parseAnything` function.

Now, it parses
- hex colors without `#` prefix
- oklab and oklch with only three numbers separated by spaces, and
- try parse into oklab if the second or third number is negative
- try parse into current notation if all numbers are positive